### PR TITLE
Correct rune width

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -54,7 +54,7 @@ func rune_advance_len(r rune, pos int) int {
 		// for invisible chars like ^R ^@ and such, two cells
 		return 2
 	}
-	return 1
+	return runeWidth(r)
 }
 
 func vlen(data []byte, pos int) int {

--- a/view.go
+++ b/view.go
@@ -242,6 +242,22 @@ func (v *view) width() int {
 	return v.uibuf.Width
 }
 
+func runeWidth(r rune) int {
+	if r >= 0x1100 &&
+		(r <= 0x115f || r == 0x2329 || r == 0x232a ||
+			(r >= 0x2e80 && r <= 0xa4cf && r != 0x303f) ||
+			(r >= 0xac00 && r <= 0xd7a3) ||
+			(r >= 0xf900 && r <= 0xfaff) ||
+			(r >= 0xfe30 && r <= 0xfe6f) ||
+			(r >= 0xff00 && r <= 0xff60) ||
+			(r >= 0xffe0 && r <= 0xffe6) ||
+			(r >= 0x20000 && r <= 0x2fffd) ||
+			(r >= 0x30000 && r <= 0x3fffd)) {
+		return 2
+	}
+	return 1
+}
+
 func (v *view) draw_line(line *line, line_num, coff, line_voffset int) {
 	x := 0
 	tabstop := 0
@@ -313,7 +329,7 @@ func (v *view) draw_line(line *line, line_num, coff, line_voffset int) {
 				v.uibuf.Cells[coff+rx] = v.make_cell(
 					line_num, bx, r)
 			}
-			x++
+			x += runeWidth(r)
 		}
 		data = data[rlen:]
 		bx += rlen


### PR DESCRIPTION
https://github.com/nsf/termbox-go/pull/21

I know runWidth is in also termbox-go. So if you mind this, please move it into some where.
And I'll working to add utf8.RuneWidth() into unicode/utf8 after the release of go1.1
