### PR TITLE
Use dash.

### DIFF
--- a/view.go
+++ b/view.go
@@ -376,7 +376,7 @@ func (v *view) draw_status() {
 	v.uibuf.Fill(tulib.Rect{0, v.height(), v.uibuf.Width, 1}, termbox.Cell{
 		Fg: termbox.AttrReverse,
 		Bg: termbox.AttrReverse,
-		Ch: '─',
+		Ch: '-',
 	})
 
 	// on disk sync status


### PR DESCRIPTION
`─` is single cells in english locales, but in asia locales, it is two cells.
