### PR TITLE
Add C-l. Recenter view function.

### DIFF
--- a/README
+++ b/README
@@ -71,6 +71,7 @@ Cursor/view movement and text editing:
   C-a, <home>      - Move cursor to the beginning of the line
   C-v, <pgdn>      - Move view forward (half of the screen)
   M-v, <pgup>      - Move view backward (half of the screen)
+  C-l              - Center view on line containing cursor
   C-s              - Search forward [interactive prompt]
   C-r              - Search backward [interactive prompt]
   C-j              - Insert a newline character and autoindent

--- a/view.go
+++ b/view.go
@@ -1111,6 +1111,8 @@ func (v *view) on_vcommand(cmd vcommand, arg rune) {
 		v.set_mark()
 	case vcommand_swap_cursor_and_mark:
 		v.swap_cursor_and_mark()
+	case vcommand_recenter:
+		v.center_view_on_cursor()
 	case vcommand_insert_rune:
 		v.insert_rune(arg)
 	case vcommand_yank:
@@ -1187,6 +1189,8 @@ func (v *view) on_key(ev *termbox.Event) {
 		v.on_vcommand(vcommand_move_cursor_beginning_of_line, 0)
 	case termbox.KeyCtrlV, termbox.KeyPgdn:
 		v.on_vcommand(vcommand_move_view_half_forward, 0)
+	case termbox.KeyCtrlL:
+		v.on_vcommand(vcommand_recenter, 0)
 	case termbox.KeyCtrlSlash:
 		v.on_vcommand(vcommand_undo, 0)
 	case termbox.KeySpace:
@@ -1824,6 +1828,7 @@ const (
 	vcommand_move_view_half_backward
 	vcommand_set_mark
 	vcommand_swap_cursor_and_mark
+	vcommand_recenter
 	_vcommand_movement_end
 
 	// insertion commands


### PR DESCRIPTION
This gives keyboard access to the existing center_view_on_cursor() method of a view.