### PR TITLE
render ASCII on windows

### DIFF
--- a/godit.go
+++ b/godit.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 )
 
@@ -346,17 +347,31 @@ func (g *godit) composite_recursively(v *view_tree) {
 		splitter := v.right.Rect
 		splitter.X -= 1
 		splitter.Width = 1
-		g.uibuf.Fill(splitter, termbox.Cell{
-			Fg: termbox.AttrReverse,
-			Bg: termbox.AttrReverse,
-			Ch: '│',
-		})
-		g.uibuf.Set(splitter.X, splitter.Y+splitter.Height-1,
-			termbox.Cell{
+		if runtime.GOOS == "windows" {
+			g.uibuf.Fill(splitter, termbox.Cell{
 				Fg: termbox.AttrReverse,
 				Bg: termbox.AttrReverse,
-				Ch: '┴',
+				Ch: '|',
 			})
+			g.uibuf.Set(splitter.X, splitter.Y+splitter.Height-1,
+				termbox.Cell{
+					Fg: termbox.AttrReverse,
+					Bg: termbox.AttrReverse,
+					Ch: '+',
+				})
+		} else {
+			g.uibuf.Fill(splitter, termbox.Cell{
+				Fg: termbox.AttrReverse,
+				Bg: termbox.AttrReverse,
+				Ch: '│',
+			})
+			g.uibuf.Set(splitter.X, splitter.Y+splitter.Height-1,
+				termbox.Cell{
+					Fg: termbox.AttrReverse,
+					Bg: termbox.AttrReverse,
+					Ch: '┴',
+				})
+		}
 	} else {
 		g.composite_recursively(v.top)
 		g.composite_recursively(v.bottom)
@@ -371,21 +386,39 @@ func (g *godit) fix_edges(v *view_tree) {
 		x = v.X - 1
 		cell = g.uibuf.Get(x, y)
 		if cell != nil {
-			switch cell.Ch {
-			case '│':
-				cell.Ch = '├'
-			case '┤':
-				cell.Ch = '┼'
+			if runtime.GOOS == "windows" {
+				switch cell.Ch {
+				case '|':
+					cell.Ch = '+'
+				case '+':
+					cell.Ch = '+'
+				}
+			} else {
+				switch cell.Ch {
+				case '│':
+					cell.Ch = '├'
+				case '┤':
+					cell.Ch = '┼'
+				}
 			}
 		}
 		x = v.X + v.Width
 		cell = g.uibuf.Get(x, y)
 		if cell != nil {
-			switch cell.Ch {
-			case '│':
-				cell.Ch = '┤'
-			case '├':
-				cell.Ch = '┼'
+			if runtime.GOOS == "windows" {
+				switch cell.Ch {
+				case '|':
+					cell.Ch = '+'
+				case '+':
+					cell.Ch = '+'
+				}
+			} else {
+				switch cell.Ch {
+				case '│':
+					cell.Ch = '┤'
+				case '├':
+					cell.Ch = '┼'
+				}
 			}
 		}
 		return
@@ -396,11 +429,20 @@ func (g *godit) fix_edges(v *view_tree) {
 		y = v.right.Y - 1
 		cell = g.uibuf.Get(x, y)
 		if cell != nil {
-			switch cell.Ch {
-			case '─':
-				cell.Ch = '┬'
-			case '┴':
-				cell.Ch = '┼'
+			if runtime.GOOS == "windows" {
+				switch cell.Ch {
+				case '-':
+					cell.Ch = '+'
+				case '+':
+					cell.Ch = '+'
+				}
+			} else {
+				switch cell.Ch {
+				case '─':
+					cell.Ch = '┬'
+				case '┴':
+					cell.Ch = '┼'
+				}
 			}
 		}
 		g.fix_edges(v.left)

--- a/view.go
+++ b/view.go
@@ -264,10 +264,18 @@ func (v *view) draw_line(line *line, line_num, coff, line_voffset int) {
 
 		if rx >= v.uibuf.Width {
 			last := coff + v.uibuf.Width - 1
-			v.uibuf.Cells[last] = termbox.Cell{
-				Ch: '→',
-				Fg: termbox.ColorDefault,
-				Bg: termbox.ColorDefault,
+			if runtime.GOOS == "windows" {
+				v.uibuf.Cells[last] = termbox.Cell{
+					Ch: '>',
+					Fg: termbox.ColorDefault,
+					Bg: termbox.ColorDefault,
+				}
+			} else {
+				v.uibuf.Cells[last] = termbox.Cell{
+					Ch: '→',
+					Fg: termbox.ColorDefault,
+					Bg: termbox.ColorDefault,
+				}
 			}
 			break
 		}
@@ -321,10 +329,18 @@ func (v *view) draw_line(line *line, line_num, coff, line_voffset int) {
 	}
 
 	if line_voffset != 0 {
-		v.uibuf.Cells[coff] = termbox.Cell{
-			Ch: '←',
-			Fg: termbox.ColorDefault,
-			Bg: termbox.ColorDefault,
+		if runtime.GOOS == "windows" {
+			v.uibuf.Cells[coff] = termbox.Cell{
+				Ch: '<',
+				Fg: termbox.ColorDefault,
+				Bg: termbox.ColorDefault,
+			}
+		} else {
+			v.uibuf.Cells[coff] = termbox.Cell{
+				Ch: '←',
+				Fg: termbox.ColorDefault,
+				Bg: termbox.ColorDefault,
+			}
 		}
 	}
 }

--- a/view.go
+++ b/view.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nsf/termbox-go"
 	"github.com/nsf/tulib"
 	"os"
+	"runtime"
 	"strings"
 	"unicode/utf8"
 )
@@ -373,11 +374,19 @@ func (v *view) draw_status() {
 	lp := tulib.DefaultLabelParams
 	lp.Bg = termbox.AttrReverse
 	lp.Fg = termbox.AttrReverse | termbox.AttrBold
-	v.uibuf.Fill(tulib.Rect{0, v.height(), v.uibuf.Width, 1}, termbox.Cell{
-		Fg: termbox.AttrReverse,
-		Bg: termbox.AttrReverse,
-		Ch: '─',
-	})
+	if runtime.GOOS == "windows" {
+		v.uibuf.Fill(tulib.Rect{0, v.height(), v.uibuf.Width, 1}, termbox.Cell{
+			Fg: termbox.AttrReverse,
+			Bg: termbox.AttrReverse,
+			Ch: '-',
+		})
+	} else {
+		v.uibuf.Fill(tulib.Rect{0, v.height(), v.uibuf.Width, 1}, termbox.Cell{
+			Fg: termbox.AttrReverse,
+			Bg: termbox.AttrReverse,
+			Ch: '─',
+		})
+	}
 
 	// on disk sync status
 	if !v.buf.synced_with_disk() {

--- a/view_op_mode.go
+++ b/view_op_mode.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/nsf/termbox-go"
 	"github.com/nsf/tulib"
+	"runtime"
 )
 
 //----------------------------------------------------------------------------
@@ -75,11 +76,19 @@ func (v view_op_mode) draw() {
 	hr.X += (r.Width - 1) / 2
 	hr.Width = 1
 	hr.Height = 3
-	g.uibuf.Fill(hr, termbox.Cell{
-		Fg: termbox.ColorWhite,
-		Bg: termbox.ColorRed,
-		Ch: '│',
-	})
+	if runtime.GOOS == "windows" {
+		g.uibuf.Fill(hr, termbox.Cell{
+			Fg: termbox.ColorWhite,
+			Bg: termbox.ColorRed,
+			Ch: '|',
+		})
+	} else {
+		g.uibuf.Fill(hr, termbox.Cell{
+			Fg: termbox.ColorWhite,
+			Bg: termbox.ColorRed,
+			Ch: '│',
+		})
+	}
 
 	x = hr.X
 	y = hr.Y + 1
@@ -94,11 +103,19 @@ func (v view_op_mode) draw() {
 	vr.Y += (r.Height - 1) / 2
 	vr.Height = 1
 	vr.Width = 5
-	g.uibuf.Fill(vr, termbox.Cell{
-		Fg: termbox.ColorWhite,
-		Bg: termbox.ColorRed,
-		Ch: '─',
-	})
+	if runtime.GOOS == "windows" {
+		g.uibuf.Fill(vr, termbox.Cell{
+			Fg: termbox.ColorWhite,
+			Bg: termbox.ColorRed,
+			Ch: '-',
+		})
+	} else {
+		g.uibuf.Fill(vr, termbox.Cell{
+			Fg: termbox.ColorWhite,
+			Bg: termbox.ColorRed,
+			Ch: '─',
+		})
+	}
 
 	x = vr.X + 2
 	y = vr.Y


### PR DESCRIPTION
As you know, on windows, there are some unicode points that doesn't render correctly.
For example, east asian ambiguous width. It is not a problem of godit. Not a problem of termbox-go. it is a problem of ambiguous character widths. so i want to suggest to use ASCII characters for rendering borders on windows.

Before
![](http://go-gyazo.appspot.com/3292d46298561745.png)

After
![](http://go-gyazo.appspot.com/2aabf824125de27b.png)

Currenly, this is ugly patch. if you want this change, I'll update.