### PR TITLE
Fix minor cursor position bug with no-op 'C-x <'

### DIFF
--- a/view.go
+++ b/view.go
@@ -1529,11 +1529,11 @@ func (v *view) deindent_line(line cursor_location) {
 	line.boffset = 0
 	if r, _ := line.rune_under(); r == '\t' {
 		v.action_delete(line, 1)
-	}
-	if v.cursor.line == line.line && v.cursor.boffset > 0 {
-		cursor := v.cursor
-		cursor.boffset -= 1
-		v.move_cursor_to(cursor)
+		if v.cursor.line == line.line && v.cursor.boffset > 0 {
+			cursor := v.cursor
+			cursor.boffset -= 1
+			v.move_cursor_to(cursor)
+		}
 	}
 }
 


### PR DESCRIPTION
`C-x <` has a very minor cursor position issue: it moves the cursor one byte to the left even if the current line had no indentation and the operation was a no-op for it.

To reproduce, mark a region ending with a line that has no indentation, putting the cursor on a column greater than zero.  Then invoke `C-x <`: it will move the cursor one byte to the left even though the line is unchanged, and repeating the operation with `<` will continue to move the cursor to the left each time.

The idea with moving the cursor to the left is to adjust for the deleted tab, but if no tab was deleted, then the cursor should remain where it was.