### PR TITLE
Support suspend on all POSIX systems

### DIFF
--- a/suspend.go
+++ b/suspend.go
@@ -1,6 +1,6 @@
-// +build !linux
+// +build android plan9 nacl windows
 
 package main
 
-// do nothing, it's a linux specific feature at the moment
+// do nothing, it's a posix specific feature at the moment
 func suspend(g *godit) {}

--- a/suspend_posix.go
+++ b/suspend_posix.go
@@ -1,3 +1,5 @@
+// +build linux darwin dragonfly solaris openbsd netbsd freebsd
+
 package main
 
 import (
@@ -11,8 +13,7 @@ func suspend(g *godit) {
 
 	// suspend the process
 	pid := syscall.Getpid()
-	tid := syscall.Gettid()
-	err := syscall.Tgkill(pid, tid, syscall.SIGSTOP)
+	err := syscall.Kill(pid, syscall.SIGSTOP)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Credit where credit is due: this change comes verbatim from Gomacs[^0] which, in turn, adapted it from Micro.[^1]

With this change applied, I tested suspend and resume of `godit` on Linux, FreeBSD, and macOS: it works.

[^0]: https://github.com/japanoise/gomacs/commit/052fe38aeac0b5076241b119ea60cd2dc60ddaf0
[^1]: https://github.com/zyedidia/micro/commit/315391b0aa740a0e1757dd098db9b